### PR TITLE
Add nginx reverse proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ cp .env.example .env        # edit passwords
 docker compose up --build
 ```
 
-Stream at `http://localhost:8000/stream`. Status page at `http://localhost:8000`.
+Web player at `http://localhost:8080`. Direct stream at `http://localhost:8000/stream`. Status page at `http://localhost:8000`.
+
+The web container proxies `/stream` and `/status-json.xsl` to Icecast so the browser can use same-origin URLs.
 
 ## What's built
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,3 +25,14 @@ services:
     depends_on:
       - icecast
     restart: unless-stopped
+
+  web:
+    image: nginx:1.27-alpine
+    ports:
+      - "8080:80"
+    volumes:
+      - ./web:/usr/share/nginx/html:ro
+      - ./web/nginx.conf:/etc/nginx/conf.d/default.conf:ro
+    depends_on:
+      - icecast
+    restart: unless-stopped

--- a/web/nginx.conf
+++ b/web/nginx.conf
@@ -1,0 +1,26 @@
+server {
+  listen 80;
+  server_name _;
+
+  root /usr/share/nginx/html;
+  index index.html;
+
+  location / {
+    try_files $uri $uri/ /index.html;
+  }
+
+  location /stream {
+    proxy_pass http://icecast:8000/stream;
+    proxy_buffering off;
+    proxy_read_timeout 24h;
+
+    proxy_set_header Host $host;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+  }
+
+  location /status-json.xsl {
+    proxy_pass http://icecast:8000/status-json.xsl;
+    proxy_buffering off;
+  }
+}


### PR DESCRIPTION
# Summary

Running the web frontend and Icecast on different ports results in CORS issues. This PR adds a nginx container that serves the static web frontend and proxies the Icecast stream and status endpoints under the same origin.

