### PR TITLE
feat: set up Discord bot (authenticate + read messages)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,23 @@ docker compose up --build
 
 Stream at `http://localhost:8000/stream`. Status page at `http://localhost:8000`.
 
+## Discord bot
+
+The scraper bot reads song links from a Discord channel. To set it up:
+
+1. Create a bot at https://discord.com/developers/applications
+2. Under **Bot** settings, enable **Message Content Intent**
+3. Invite the bot to your server with `Send Messages` and `Read Message History` permissions
+4. Copy the bot token into `DISCORD_BOT_TOKEN` in your `.env`
+5. Right-click the target channel/thread and copy its ID into `DISCORD_CHANNEL_ID`
+
+Run the bot:
+
+```bash
+pip install -r scraper/requirements.txt
+python scraper/bot.py
+```
+
 ## What's built
 
 - Liquidsoap shuffles and crossfades tracks from the music directory

--- a/scraper/bot.py
+++ b/scraper/bot.py
@@ -1,0 +1,56 @@
+"""Authenticate with Discord, fetch messages from a channel, and print them."""
+
+import os
+import sys
+
+import discord
+from dotenv import load_dotenv
+
+
+def main() -> None:
+    load_dotenv()
+
+    token = os.getenv("DISCORD_BOT_TOKEN")
+    channel_id = os.getenv("DISCORD_CHANNEL_ID")
+
+    if not token:
+        print("ERROR: DISCORD_BOT_TOKEN not set in .env", file=sys.stderr)
+        sys.exit(1)
+    if not channel_id:
+        print("ERROR: DISCORD_CHANNEL_ID not set in .env", file=sys.stderr)
+        sys.exit(1)
+
+    intents = discord.Intents.default()
+    intents.message_content = True
+
+    client = discord.Client(intents=intents)
+
+    @client.event
+    async def on_ready() -> None:
+        print(f"Logged in as {client.user} (ID: {client.user.id})")
+        try:
+            channel = client.get_channel(int(channel_id))
+            if channel is None:
+                channel = await client.fetch_channel(int(channel_id))
+        except (ValueError, discord.NotFound, discord.Forbidden) as exc:
+            print(f"ERROR: could not resolve channel: {exc}", file=sys.stderr)
+            await client.close()
+            return
+
+        print(f"Fetching messages from {channel.name} (ID: {channel.id})...")
+        try:
+            async for message in channel.history(limit=100):
+                print(f"[{message.author}] {message.content}")
+        except discord.Forbidden:
+            print(
+                "ERROR: missing permission to read message history",
+                file=sys.stderr,
+            )
+        finally:
+            await client.close()
+
+    client.run(token)
+
+
+if __name__ == "__main__":
+    main()

--- a/scraper/requirements.txt
+++ b/scraper/requirements.txt
@@ -1,0 +1,2 @@
+discord.py>=2.3,<3.0
+python-dotenv>=1.0,<2.0


### PR DESCRIPTION
## What
Set up a Discord bot that authenticates, fetches messages from a configured channel, and prints them to stdout.

## Why
Closes #1. Foundation for scraping music links from the Discord thread.

## How
- Created scraper/bot.py with discord.Client using message_content intent
- Loads DISCORD_BOT_TOKEN and DISCORD_CHANNEL_ID from .env
- Fetches last 100 messages on_ready, prints author + content
- Cleans up by closing the client after scraping
- Added scraper/requirements.txt with discord.py and python-dotenv
- Updated README with bot setup instructions

## Testing
- Run locally with: pip install -r scraper/requirements.txt && python scraper/bot.py