### PR TITLE
rewrite docs for the YouTube embed pivot

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,64 +1,71 @@
 # Contributing
 
-There are three ways to help: post music, record clips, write code.
+There are two ways to help: post music, or write code.
 
 ## Post music
 
-Drop a YouTube or Spotify link in the music thread. That's the easiest way to contribute.
-
-## Record audio clips
-
-Station IDs, DJ intros, the story behind a song you posted, weird ambient noises -- anything that could play between songs. Drop them in the Discord.
+Drop a YouTube or Spotify link in the music thread. That's the easiest way to contribute, and it's what keeps the station running.
 
 ## Write code
 
 ### Quick start
 
-You need: Docker, Docker Compose, git.
+You need: Python 3.13, git. Docker is only needed for the parts that ship as containers, and there's no streaming stack or VM to set up anymore.
 
 ```bash
 git clone https://github.com/Vimothy-s-Vestibule/vestibule-radio
 cd vestibule-radio
 cp .env.example .env
-docker compose up
 ```
 
-Open http://localhost:8001 — you should see the player. Drop an MP3 into `music/` and Liquidsoap will pick it up quickly.
+The Discord bot runs today:
 
-If you're only working on the frontend, you don't need Discord credentials in `.env` — just leave `DISCORD_BOT_TOKEN` and `DISCORD_CHANNEL_ID` blank.
+```bash
+pip install -r scraper/requirements.txt
+python scraper/bot.py
+```
+
+If you're only working on the frontend, you don't need Discord credentials in `.env`. Leave `DISCORD_BOT_TOKEN` and `DISCORD_CHANNEL_ID` blank. Playback in the web app is YouTube embeds, so you can develop it with nothing but a browser.
 
 ### Pick something to work on
 
 Browse the [issues](https://github.com/Vimothy-s-Vestibule/vestibule-radio/issues). `good first issue` is a good place to start.
 
-Comment on the issue saying you're taking it so two people don't end up doing the same thing. If you get stuck, ask in the project Discord forum — no question is too small.
+The work is organized in rough phases, so you can see where a task fits:
+
+1. **Ingestion pivot** - resolve links to video IDs and store metadata ([#26](https://github.com/Vimothy-s-Vestibule/vestibule-radio/issues/26), [#27](https://github.com/Vimothy-s-Vestibule/vestibule-radio/issues/27), [#28](https://github.com/Vimothy-s-Vestibule/vestibule-radio/issues/28), [#21](https://github.com/Vimothy-s-Vestibule/vestibule-radio/issues/21))
+2. **Minimal playback** - API server and a YouTube IFrame player ([#29](https://github.com/Vimothy-s-Vestibule/vestibule-radio/issues/29), [#30](https://github.com/Vimothy-s-Vestibule/vestibule-radio/issues/30), [#37](https://github.com/Vimothy-s-Vestibule/vestibule-radio/issues/37))
+3. **Sync and chat** - shared playback, voting, chat, login ([#31](https://github.com/Vimothy-s-Vestibule/vestibule-radio/issues/31), [#33](https://github.com/Vimothy-s-Vestibule/vestibule-radio/issues/33), [#34](https://github.com/Vimothy-s-Vestibule/vestibule-radio/issues/34), [#35](https://github.com/Vimothy-s-Vestibule/vestibule-radio/issues/35))
+4. **Polish and mobile** - PWA, smart queue, desync handling ([#36](https://github.com/Vimothy-s-Vestibule/vestibule-radio/issues/36), [#38](https://github.com/Vimothy-s-Vestibule/vestibule-radio/issues/38), [#32](https://github.com/Vimothy-s-Vestibule/vestibule-radio/issues/32))
+
+Comment on the issue saying you're taking it so two people don't end up doing the same thing. If you get stuck, ask in the project Discord forum. No question is too small.
 
 ### Submitting changes
 
-1. Branch off `main`
-2. Keep PRs small and focused - one thing per PR
+1. **Work on a feature branch, not `main`.** Branch off `main` and open your PR from that branch. A couple of early PRs came straight off `main` and caused friction, so this one matters.
+2. Keep PRs small and focused, one thing per PR
 3. Write a clear PR description: what changed, why, how to test it
-4. Link the issue it closes (`Closes #14`)
+4. Link the issue it closes (`Closes #30`)
+
+PRs are reviewed by a maintainer before they're merged, so expect some back and forth.
 
 ### Project layout
 
 | Path | What it is |
 |------|------------|
-| `web/` | Static frontend (HTML/CSS/JS, no build step) |
-| `scraper/` | Discord bot + audio downloader |
-| `streaming/` | Liquidsoap config |
+| `web/` | Static frontend (HTML/CSS/JS, no build step), YouTube IFrame player |
+| `scraper/` | Discord bot, link parser, and Spotify to YouTube resolver |
 | `data/` | JSON state files (tracks, votes, recent plays) |
-| `music/` | Downloaded MP3s — gitignored |
 | `docs/` | Architecture and design notes |
 
 See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for how the pieces fit together.
 
 ### Working on one piece in isolation
 
-You don't always need the full stack running:
+You don't always need everything running:
 
-- **Frontend only:** `cd web && python3 -m http.server 8001` Stream won't play but UI works.
-- **Smart queue / downloader / other Python scripts:** runnable standalone with fixture data, no Docker needed.
+- **Frontend only:** `cd web && python3 -m http.server 8001`. The player embeds run against YouTube directly.
+- **Resolver, parser, or other Python scripts:** runnable standalone with fixture data, no Docker needed.
 - **Discord bot:** needs a bot token in `.env`, but you can point it at a private test server instead of the real Vestibule one.
 
 ## Code of conduct

--- a/README.md
+++ b/README.md
@@ -1,28 +1,35 @@
 # Vestibule Community Radio
 
-A 24/7 radio station for the Vestibule community. Post a YouTube or Spotify link in the music thread and it ends up on the station.
+A 24/7 listening room for the Vestibule community. Post a YouTube or Spotify link in the music thread and it gets added to the station. Everyone tuned in hears the same song at the same time, right in the browser.
 
-The stream is running. Sylvan is getting it set up on the server -- link coming soon.
+The radio plays songs through YouTube's embedded player, so the audio comes straight from YouTube. We don't host or stream any audio ourselves.
 
 ## Get your music on the radio
 
-Post a YouTube or Spotify link in the music thread. That's it. The system downloads it and adds it to the rotation. The web player will show who posted each song.
+Post a YouTube or Spotify link in the music thread. That's it. The bot picks it up, finds the matching YouTube video, and adds it to the rotation. Spotify links get matched to a YouTube version automatically, since that's what the player can embed. The web player shows who posted each song.
+
+## How it works
+
+- The Discord bot watches the music thread and pulls out every YouTube and Spotify link.
+- Spotify links are resolved to a matching YouTube video, because only YouTube can be embedded.
+- Each track is stored as a YouTube video ID plus metadata (title, artist, genre, who posted it). No audio files.
+- The web app plays the queue through the YouTube IFrame player, kept in sync across listeners by the server.
 
 ## Run it locally
 
+The web app and the bot run locally. Playback is just YouTube embeds in your browser, so there's no streaming server or media to host, and no VM required.
+
 ```bash
-git clone https://github.com/jack123xyz/vestibule-radio.git
+git clone https://github.com/Vimothy-s-Vestibule/vestibule-radio
 cd vestibule-radio
-cp .env.example .env        # edit passwords
-                             # drop some mp3s in music/
-docker compose up --build
+cp .env.example .env        # edit values
 ```
 
-Stream at `http://localhost:8000/stream`. Status page at `http://localhost:8000`.
+The project is mid-pivot, so the pieces are still coming together. The Discord bot and link parser run today. The API, sync server, and web player are in active development, tracked in the [issues](https://github.com/Vimothy-s-Vestibule/vestibule-radio/issues).
 
 ## Discord bot
 
-The scraper bot reads song links from a Discord channel. To set it up:
+The bot reads song links from a Discord channel. To set it up:
 
 1. Create a bot at https://discord.com/developers/applications
 2. Under **Bot** settings, enable **Message Content Intent**
@@ -37,20 +44,22 @@ pip install -r scraper/requirements.txt
 python scraper/bot.py
 ```
 
+It runs in two modes: `--listen` (default) processes new posts as they arrive, and `--backfill` reads the channel history once and then exits.
+
 ## What's built
 
-- Liquidsoap shuffles and crossfades tracks from the music directory
-- Icecast serves the stream over HTTP
-- Docker Compose runs the whole thing
+- **Discord bot** connects to the music thread, with listen and backfill modes and graceful shutdown
+- **Link parser** extracts and normalizes YouTube and Spotify links from messages, and dedupes them
 
 ## What we're building next
 
-- **Discord bot** that automatically grabs links from the music thread and downloads them ([issues](https://github.com/jack123xyz/vestibule-radio/issues?q=label%3Abot))
-- **Web player** so people can listen in a browser ([issues](https://github.com/jack123xyz/vestibule-radio/issues?q=label%3Afrontend))
-- **Smart queue** that avoids repeats and lets listeners upvote/downvote songs
+- **Spotify to YouTube resolver** so Spotify links can be embedded ([#27](https://github.com/Vimothy-s-Vestibule/vestibule-radio/issues/27))
+- **Web player** using the YouTube IFrame API ([#30](https://github.com/Vimothy-s-Vestibule/vestibule-radio/issues/30))
+- **WebSocket sync server** so everyone hears the same song at the same time ([#31](https://github.com/Vimothy-s-Vestibule/vestibule-radio/issues/31))
+- **Chat and live voting** for the next track ([#33](https://github.com/Vimothy-s-Vestibule/vestibule-radio/issues/33), [#34](https://github.com/Vimothy-s-Vestibule/vestibule-radio/issues/34))
 
 ## Help out
 
-Check the [issues](https://github.com/jack123xyz/vestibule-radio/issues). Pick something, open a PR. If you don't code, post music, record audio clips for between songs, or share design ideas in the Discord.
+Check the [issues](https://github.com/Vimothy-s-Vestibule/vestibule-radio/issues). Pick something, open a PR. If you don't code, post music or share design ideas in the Discord.
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for setup details.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -2,60 +2,83 @@
 
 How Vestibule Community Radio works.
 
+The station plays songs through YouTube's embedded player. Listeners watch the same queue in sync, and YouTube serves the actual audio and video. We don't host or stream any audio ourselves, which keeps licensing and delivery with YouTube.
+
 ## Flow
 
-Solid arrows are built. Dashed arrows are planned.
-
 ```
-                                  ┌──────────────────────────────────────┐
-                                  │                                      │
-   [planned]                      ▼                                      │
-Discord Thread ┄┄> Bot ┄┄> Downloader ┄┄> music/ + tracks.json           │
-                                                  │                       │
-                                                  ▼                       │
-                                              Liquidsoap ──> Icecast      │
-                                                                │         │
-                                                                ▼         │
-                                                            Traefik ──> Listeners
-                                                                ▲
-                                                                │
-                                                            Frontend (web/)
+Discord Thread --> Bot --> Parser --> Resolver (Spotify to YouTube if needed)
+                                          |
+                                          v
+                              MusicBrainz enrichment
+                                          |
+                                          v
+                            Track store (video IDs + metadata)
+                                          |
+                                          v
+                    API server  <-->  WebSocket sync server
+                                          |
+                                          v
+        Web client: YouTube IFrame player + chat + queue + voting
+                                          |
+                                          v
+                    YouTube serves the audio/video
 ```
 
-Today, the music in `music/` is added manually. Once the bot + downloader land, that step becomes automatic.
+A posted link becomes a YouTube video ID plus metadata. The server decides what's playing and how far into it, and every client lines its embed up to that.
 
 ## Components
 
 | Component | Status | Notes |
 |-----------|--------|-------|
-| Frontend (`web/`) | live | Static HTML/CSS/JS, no build step |
-| Reverse proxy (Traefik + Authentik) | live in prod, dev WIP | Routes `/`, `/stream`, `/status-json.xsl` to the right backend. Every route is gated by Authentik - the station is members-only. |
-| Stream server (Icecast) | live | Serves the audio stream + metadata JSON |
-| Playout (Liquidsoap) | live | Shuffles `music/`, crossfades, normalizes, pushes to Icecast |
-| Discord bot | planned | Issues [#1](https://github.com/Vimothy-s-Vestibule/vestibule-radio/issues/1), [#2](https://github.com/Vimothy-s-Vestibule/vestibule-radio/issues/2) |
-| Downloader | planned | Issue [#3](https://github.com/Vimothy-s-Vestibule/vestibule-radio/issues/3) |
-| Smart queue | planned | Issue [#14](https://github.com/Vimothy-s-Vestibule/vestibule-radio/issues/14) |
-| Voting / now-playing wiring | planned | Issue [#13](https://github.com/Vimothy-s-Vestibule/vestibule-radio/issues/13) |
-| Taste map | planned | Issue [#12](https://github.com/Vimothy-s-Vestibule/vestibule-radio/issues/12) |
+| Discord bot | built | Watches the music thread, listen + backfill modes, graceful shutdown |
+| Link parser | built | Extracts and normalizes YouTube and Spotify URLs, dedupes |
+| Spotify to YouTube resolver | planned | Matches a Spotify link to a YouTube video ID, ISRC first, falling back to "Artist - Song" plus duration. [#27](https://github.com/Vimothy-s-Vestibule/vestibule-radio/issues/27) |
+| MusicBrainz enrichment | planned | Fills in genre and cleans metadata for the UI. [#21](https://github.com/Vimothy-s-Vestibule/vestibule-radio/issues/21) |
+| Track store | planned | Video IDs + metadata. JSON to start, SQLite when it hurts. Schema in [#28](https://github.com/Vimothy-s-Vestibule/vestibule-radio/issues/28) |
+| API server | planned | Serves the queue and track list to the frontend. [#29](https://github.com/Vimothy-s-Vestibule/vestibule-radio/issues/29) |
+| WebSocket sync server | planned | Server-authoritative now-playing state and progress, plus chat and voting transport. [#31](https://github.com/Vimothy-s-Vestibule/vestibule-radio/issues/31) |
+| Web player | planned | YouTube IFrame Player API, plays the queue in sync. [#30](https://github.com/Vimothy-s-Vestibule/vestibule-radio/issues/30) |
+| Per-channel chat | planned | Over the same WebSocket layer. [#33](https://github.com/Vimothy-s-Vestibule/vestibule-radio/issues/33) |
+| Live voting | planned | Listeners vote on the next track. [#34](https://github.com/Vimothy-s-Vestibule/vestibule-radio/issues/34) |
+| Discord OAuth | planned | Identities match the community. [#35](https://github.com/Vimothy-s-Vestibule/vestibule-radio/issues/35) |
+| PWA | planned | Installable on mobile via manifest + service worker. [#36](https://github.com/Vimothy-s-Vestibule/vestibule-radio/issues/36) |
+
+The old self-hosted audio stack (downloader, Liquidsoap, Icecast) is being removed as part of the pivot, tracked in [#25](https://github.com/Vimothy-s-Vestibule/vestibule-radio/issues/25). Some of that code is still in the tree until that lands.
+
+## How sync works
+
+The sync server holds the current track and a progress counter that runs from 0 to the track's duration. When a client connects it gets the current video ID and progress, loads the embed, and uses the IFrame API `seekTo` to jump to the right spot. From there it follows the server's lead through the queue.
+
+The player has to stay visible to satisfy YouTube's terms. Small or secondary is fine, hidden is not.
+
+## Known constraints
+
+- **Mobile background playback.** YouTube embeds stop when the phone is locked or the app is backgrounded, since uninterrupted background play is a Premium feature. Picture-in-Picture helps on Android. We ship YouTube only and revisit this if it turns into a real pain point. We do not work around it by downloading audio, since that brings back the liability the pivot removed.
+- **Ad-induced desync.** When a client's embed plays a YouTube ad, that client falls behind the server's timestamp. We detect the stall and `seekTo` the correct position once playback resumes. Temporary per-client desync during ads is accepted. Tracked in [#32](https://github.com/Vimothy-s-Vestibule/vestibule-radio/issues/32).
 
 ## Data files
 
 | File | Purpose |
 |------|---------|
-| `data/tracks.json` | Every downloaded track: title, artist, who posted it, file path, etc. |
+| `data/tracks.json` | Every track: YouTube video ID, title, artist, genre, who posted it, when. No file paths |
 | `data/seen_links.json` | URLs already processed, for deduplication |
 | `data/feedback.json` | Thumbs up/down tallies per track |
 | `data/recent_plays.json` | Last N track IDs, used by the smart queue to avoid repeats |
 
-Schema for `tracks.json` is defined in issue [#4](https://github.com/Vimothy-s-Vestibule/vestibule-radio/issues/4).
+The track schema is being updated for the embed model in [#28](https://github.com/Vimothy-s-Vestibule/vestibule-radio/issues/28).
 
-## Deployment
+## Tech stack
 
-**Local:** `docker compose up` runs Icecast + Liquidsoap. The frontend can be served with `python3 -m http.server` from `web/` or via the dev Traefik setup once that lands.
-
-**Prod:** the stack runs on Sylvan's cluster at `radio.vestibule.gripe`, joined to the external Docker network `proxy`. Traefik (already on the cluster) handles TLS via `websecure` and routes by Host/PathPrefix labels. The `authentik-auth@file` middleware is attached to every router - frontend, stream, metadata, and admin all require a Vestibule login. The radio is members-only by design.
+- **Backend and bot:** Python (discord.py for the bot, FastAPI for the API and WebSocket layer)
+- **Frontend:** Web app using the YouTube IFrame Player API, packaged as a PWA for mobile
+- **Realtime:** WebSocket, chosen over SSE so chat and voting can share one transport
+- **Storage:** JSON, moving to SQLite when it hurts
+- **Auth:** Discord OAuth
+- **Deployment:** Docker Compose. The stack is the bot, the API and sync server, and a static frontend. There are no streaming containers.
 
 ## Related projects
 
-[`server-library`](https://github.com/Vimothy-s-Vestibule/server-library) is a separate Vestibule project that catalogues members' books / music / movies into a SQLite-backed static site. There's been discussion of feeding radio plays into it (so a member's "music shelf" reflects what they've shared on the station), but no integration is built yet.
+The radio and the planned **Vestibule TV** converge under this architecture. Both are "play curated YouTube content from the community with shared chat." Radio is a music-focused UI with a small player, TV is a video-focused UI. Same backend and pipeline, different frontend mode. The radio web app is the immediate deliverable.
 
+[`server-library`](https://github.com/Vimothy-s-Vestibule/server-library) is a separate Vestibule project that catalogues members' books, music, and movies into a SQLite-backed static site. There's been discussion of feeding radio plays into it, but no integration is built yet.


### PR DESCRIPTION
reframe the project around synced YouTube embed playback instead of self-hosted streaming. drop liquidsoap/icecast/download references, add the resolver, api, sync server, chat and voting direction, and document the mobile and ad desync constraints honestly.

point contributors at the phased issue set and stress feature branches.