### PR TITLE
API server to serve the track queue

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.13-slim
+
+WORKDIR /app
+
+COPY api/requirements.txt ./api/requirements.txt
+RUN pip install --no-cache-dir -r api/requirements.txt
+
+COPY api ./api
+
+EXPOSE 8002
+
+CMD ["uvicorn", "api.main:app", "--host", "0.0.0.0", "--port", "8002"]

--- a/api/main.py
+++ b/api/main.py
@@ -1,0 +1,53 @@
+"""Vestibule Radio API, serves the track queue to the frontend.
+
+REST only for now. The sync server, chat, and voting (separate issues) will be
+WebSocket layers added onto this same app, so keep the app object reusable and
+don't bake in REST-only assumptions.
+"""
+
+import os
+
+from fastapi import FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+
+from .models import Track
+from .store import get_track, load_tracks
+
+# comma-separated origins, e.g. "http://localhost:8001,http://localhost:3000"
+CORS_ORIGINS = [
+    origin.strip()
+    for origin in os.getenv("CORS_ORIGINS", "http://localhost:8001").split(",")
+    if origin.strip()
+]
+
+app = FastAPI(title="Vestibule Radio API")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=CORS_ORIGINS,
+    allow_methods=["GET"],
+    allow_headers=["*"],
+)
+
+
+@app.get("/queue", response_model=list[Track])
+@app.get("/tracks", response_model=list[Track])
+def queue() -> list[Track]:
+    return load_tracks()
+
+
+@app.get("/tracks/{video_id}", response_model=Track)
+def track(video_id: str) -> Track:
+    found = get_track(video_id)
+    if found is None:
+        raise HTTPException(status_code=404, detail=f"No track with video_id {video_id}")
+
+    return found
+
+
+@app.get("/now-playing", response_model=Track | None)
+def now_playing() -> Track | None:
+    # placeholder until the sync server exists. for now just the head of the
+    # queue so the frontend has something real to render
+    tracks = load_tracks()
+    return tracks[0] if tracks else None

--- a/api/models.py
+++ b/api/models.py
@@ -1,0 +1,25 @@
+"""Track models served by the API. Reuses the downloader's TrackMetadata shape."""
+
+from pydantic import BaseModel
+
+
+class TrackMetadata(BaseModel):
+    # video_id is the bare youtube id and the store key; it's what the frontend
+    # feeds to the player. mbid is the musicbrainz id from the enhancer.
+    video_id: str
+    title: str = ""
+    artist: str = ""
+    album: str = ""
+    genres: list[str] = []
+    mbid: str = ""
+    duration_seconds: float = 0.0
+
+
+class Track(TrackMetadata):
+    # the posting context the parser records on top of the metadata.
+    # url is the original posted link (spotify or youtube); video_id is the
+    # resolved youtube id that actually plays.
+    url: str = ""
+    source: str = ""
+    posted_by: str = ""
+    posted_at: str = ""

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,0 +1,2 @@
+fastapi==0.103.2
+uvicorn==0.23.2

--- a/api/store.py
+++ b/api/store.py
@@ -1,0 +1,60 @@
+"""Thin read layer over the track store.
+
+Everything that touches persistence goes through here, so swapping the JSON
+file for SQLite later is a change in this file only. The store is currently
+data/tracks.json, written by the parser/resolver step.
+"""
+
+import json
+import os
+from pathlib import Path
+
+from .models import Track
+
+TRACKS_PATH = Path(os.getenv("TRACKS_PATH", "data/tracks.json"))
+
+
+def load_tracks() -> list[Track]:
+    if not TRACKS_PATH.exists():
+        return []
+
+    try:
+        with open(TRACKS_PATH, encoding="utf-8") as f:
+            data = json.load(f)
+    except (json.JSONDecodeError, OSError):
+        return []
+
+    # tracks.json may be a {video_id: track} map or a bare list, accept both
+    if isinstance(data, dict):
+        raw_tracks = data.get("tracks", data).values()
+    elif isinstance(data, list):
+        raw_tracks = data
+    else:
+        return []
+
+    tracks = []
+    for raw in raw_tracks:
+        # skip malformed rows rather than 500 the whole queue
+        track = _parse_track(raw)
+        if track is not None:
+            tracks.append(track)
+
+    return tracks
+
+
+def get_track(video_id: str) -> Track | None:
+    for track in load_tracks():
+        if track.video_id == video_id:
+            return track
+
+    return None
+
+
+def _parse_track(raw) -> Track | None:
+    if not isinstance(raw, dict):
+        return None
+
+    try:
+        return Track(**raw)
+    except (TypeError, ValueError):
+        return None

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+services:
+  api:
+    build:
+      context: .
+      dockerfile: api/Dockerfile
+    ports:
+      - "8002:8002"
+    environment:
+      - TRACKS_PATH=/app/data/tracks.json
+      - CORS_ORIGINS=${CORS_ORIGINS:-http://localhost:8001}
+    volumes:
+      # read the track store the bot/parser writes; read-only, the API never writes
+      - ./data:/app/data:ro
+    restart: unless-stopped


### PR DESCRIPTION
Closes #29.

A small FastAPI app that reads the track store and serves it to the frontend. No audio is hosted or streamed here; the frontend plays via the YouTube IFrame API.

## What's here
- `api/models.py`: `Track` model reusing the downloader's `TrackMetadata` shape.
- `api/store.py`: single thin loader (`load_tracks` / `get_track`), the seam for the future JSON to SQLite swap. Returns `[]` on a missing or corrupt store and skips malformed rows so a bad row can't take down the whole queue.
- `api/main.py`: `GET /queue` (alias `/tracks`), `GET /tracks/{video_id}` (404 on miss), `GET /now-playing` (placeholder, returns head of queue until the sync server lands). CORS configured for the frontend origin. App object kept reusable so the sync/chat/voting WebSocket layers can be added without restructuring.
- Fresh `docker-compose.yml` with the `api` service (the old compose went away with the audio stack) plus `api/Dockerfile`, a slim python image running uvicorn.

## Track shape
Matches what was settled with alex for the embed pivot:
`url, posted_by, posted_at, source, video_id, mbid, title, artist, album, genres (list), duration_seconds`
- `video_id` is the bare YouTube id and the store key.
- `url` is the original posted link; for Spotify the link stays original while `video_id` holds the resolved YouTube id.
- `genres` is a short list; the frontend can use `genres[0]` when it wants a single value.

## Verified
- Runs in Docker: `docker compose up` serves uvicorn on :8002, all endpoints return correctly (queue 200, track hit 200, miss 404, now-playing 200, CORS header present).
- Loader degrades cleanly on missing file, corrupt JSON, and malformed rows.

## Notes
- Nothing writes `data/tracks.json` yet; that's the follow-up on alex's side (combine the parsed link object with the enriched metadata and write it). The API serves an empty queue until that lands.
- JSON store only for now, SQLite left as a one-function swap behind `load_tracks`.
- No WebSocket, auth, or audio code, as scoped.